### PR TITLE
fixing broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Open-Product-Management is an amazing list for people who need a refresher in Pr
 - [ ] [Product Managers: Who are these ‘mini-CEOs’ and what do they do?](http://thenextweb.com/insider/2013/10/12/product-managers-mini-ceos/) - Ken Yeung
 - [ ] [What exactly is a Product Manager? ](http://www.mindtheproduct.com/2011/10/what-exactly-is-a-product-manager/) - Martin Eriksonn
 - [ ] [What is Product Management?](http://www.sachinrekhi.com/blog/2013/01/28/what-is-product-management) - Sachin Rekhi
-- [ ] [PM at Microsoft](http://blogs.msdn.com/b/techtalk/archive/2005/12/16/504872.aspx) - Steven Sinofsky
+- [ ] [PM at Microsoft](https://blogs.msdn.microsoft.com/techtalk/2005/12/16/pm-at-microsoft/) - Steven Sinofsky
 - [ ] [Product Manager You Are…](https://medium.com/@matbalez/product-manager-you-are-664d83ee702e) - Mat Balez
 - [ ] [What Product Management is Not](http://www.svpg.com/what-product-management-is-not/) - Marty Cagan
 - [ ] (invalid link) Does the world need Product Managers any more (http://branch.com/b/does-the-world-need-product-managers-any-more) - Multiple authors


### PR DESCRIPTION
PM at Microsoft was pointing to 404. have done a google search pointed to an updated link
https://blogs.msdn.microsoft.com/techtalk/2005/12/16/pm-at-microsoft/